### PR TITLE
Fix broken interest link 250603-cng-2025-recap.md

### DIFF
--- a/content/blog/250603-cng-2025-recap.md
+++ b/content/blog/250603-cng-2025-recap.md
@@ -81,7 +81,7 @@ We will be sharing more about these findings soon.
 
 ## CNG Conference 2026
 
-Nothing’s official yet, but based on feedback from people, we’ve started planning for CNG Conference 2026. If you want to be a part of it – co-organizing, sponsoring, speaking – sign up for our [interest list](https://events.cloudnativegeo.org/cng2026interestA).
+Nothing’s official yet, but based on feedback from people, we’ve started planning for CNG Conference 2026. If you want to be a part of it – co-organizing, sponsoring, speaking – sign up for our [interest list](https://events.cloudnativegeo.org/cng2026interest).
 
 Thanks to everyone who showed up, shared their work, asked the hard questions, and made space for others to do the same. You made this real.
 


### PR DESCRIPTION
Looks like there's a typo in the interest sign-up link? Removing the `A` seemed to take me to the expected page.