### PR TITLE
CNG NYC date confirmed: September 24 at Cooper Union

### DIFF
--- a/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
+++ b/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
@@ -23,7 +23,7 @@ CNG Japan is the second stop on the 2026 CNG global event series:
 
 * London | June 23
 * Tokyo | August 24
-* NYC | late September during NYC Climate Week
+* NYC | September 24 at Cooper Union
 * CNG Forum 2026 | Snowbird, UT, USA | October 6–9
 * Zürich | October 29
 

--- a/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
+++ b/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
@@ -23,7 +23,7 @@ CNG Japan is the second stop on the 2026 CNG global event series:
 
 * London | June 23
 * Tokyo | August 24
-* NYC | September 24 at Cooper Union
+* NYC | September 24
 * CNG Forum 2026 | Snowbird, UT, USA | October 6–9
 * Zürich | October 29
 

--- a/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
+++ b/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
@@ -15,7 +15,7 @@ Talks can be given in either English or Japanese. [Submit your talk here](https:
 
 ## Colocating with STAC Sprint + FOSS4G Hiroshima
 
-Taking inspiration from the STAC community, which will also be hosting a [STAC workshop at JAXA Tsukuba](https://cloudnativegeo.org/blog/2026/06/stac-japan-2026/) (August 25–27), we wanted to host an event while we are in Japan for [FOSS4G 2026 in Hiroshima](https://foss4g.org). More importantly, we wanted to create a dedicated space for CNG practitioners to learn and share their work. Japan has a vibrant and growing cloud-native geospatial community, and this felt like the right moment to bring people together in the city before the broader conference week kicks off.
+Taking inspiration from the STAC community, which will also be hosting a [STAC workshop at JAXA Tsukuba](https://cloudnativegeo.org/blog/2026/06/announcing-stac-japan-2026/) (August 25–27), we wanted to host an event while we are in Japan for [FOSS4G 2026 in Hiroshima](https://foss4g.org). More importantly, we wanted to create a dedicated space for CNG practitioners to learn and share their work. Japan has a vibrant and growing cloud-native geospatial community, and this felt like the right moment to bring people together in the city before the broader conference week kicks off.
 
 ## Part of the 2026 CNG Series
 

--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -3,7 +3,7 @@ date: 2026-06-23
 event_date: 2026-09-24
 title: "CNG NYC"
 display_date: "24 September 2026"
-when_time: "NYC Climate Week"
+when_time: "9 AM – 5 PM, with evening reception"
 where: "Cooper Union, New York City"
 where_short: "Cooper Union"
 description: "A CNG community gathering in New York City, co-organized with the NY Climate Exchange, during NYC Climate Week."

--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -1,0 +1,20 @@
+---
+date: 2026-06-23
+event_date: 2026-09-24
+title: "CNG NYC"
+display_date: "24 September 2026"
+when_time: "NYC Climate Week"
+where: "Cooper Union, New York City"
+where_short: "Cooper Union"
+description: "A CNG community gathering in New York City, co-organized with the NY Climate Exchange, during NYC Climate Week."
+price:
+images:
+cta_text: "Register"
+cta_url:
+hide_cta: true
+agenda:
+---
+
+Join us in New York City for a day of talks, demos, and community at [Cooper Union](https://cooper.edu) during [NYC Climate Week](https://www.climateweeknyc.org). This event brings together cloud-native geospatial practitioners in one of the world's great climate and data cities to share what they're building and connect with the broader CNG community.
+
+CNG NYC is co-organized with the [NY Climate Exchange](https://nyclimateexchange.org) and is part of the [2026 CNG global event series](/events/).

--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -17,4 +17,5 @@ agenda:
 
 Join us in New York City for a day of talks, demos, and community at [Cooper Union](https://cooper.edu) during [NYC Climate Week](https://www.climateweeknyc.org). This event brings together cloud-native geospatial practitioners in one of the world's great climate and data cities to share what they're building and connect with the broader CNG community.
 
-CNG NYC is co-organized with the [NY Climate Exchange](https://nyclimateexchange.org) and is part of the [2026 CNG global event series](/events/).
+CNG NYC is part of the [2026 CNG global event series](/events/). To support the series, please see the [CNG 2026 Community Partner
+Program](https://cloudnativegeo.org/cng-2026-series-sponsor.pdf).

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -11,7 +11,7 @@
         {{if isset .Params "price"}}<li class="event-price"><span class="event-meta-tip">Cost:</span> {{ .Params.price | markdownify }}</li>{{ end }}
       {{ end }}
     </ul>
-    <div class="event-cta">{{if isset .Params "cta_url"}}<a href="{{ .Params.cta_url }}">{{end}}{{ .Params.cta_text }}{{if isset .Params "cta_url"}}</a>{{end}}</div>
+    {{if ne .Params.hide_cta true}}<div class="event-cta">{{if isset .Params "cta_url"}}<a href="{{ .Params.cta_url }}">{{end}}{{ .Params.cta_text }}{{if isset .Params "cta_url"}}</a>{{end}}</div>{{end}}
   </header>
   
   {{ if .Params.images }}


### PR DESCRIPTION
Updates the 2026 CNG series listing in the CNG Japan call-for-speakers post: late September during NYC Climate Week → September 24 at Cooper Union.