### PR TITLE
Add call for speakers blog post for CNG NYC 2026

### DIFF
--- a/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
+++ b/content/blog/2026/260611-call-for-speakers-cng-japan-2026.md
@@ -23,7 +23,7 @@ CNG Japan is the second stop on the 2026 CNG global event series:
 
 * London | June 23
 * Tokyo | August 24
-* NYC | late September during NYC Climate Week
+* NYC | September 24 at Cooper Union
 * CNG Forum 2026 | Snowbird, UT, USA | October 6–9
 * Zürich | October 29
 

--- a/content/blog/2026/260706-call-for-speakers-cng-nyc-2026.md
+++ b/content/blog/2026/260706-call-for-speakers-cng-nyc-2026.md
@@ -5,7 +5,7 @@ tags: []
 summary: "Submit a talk for CNG NYC 2026, a community meetup at Cooper Union on September 24."
 ---
 
-On September 24, 2026, the Cloud-Native Geospatial Forum (CNG) is coming to New York City. CNG NYC is a community meetup at [Cooper Union](https://cooper.edu/) designed to bring the local and regional CNG community together for an afternoon of demos, conversation, and a social reception. Whether you're a practitioner, researcher, or builder, this is a chance to show off what you're working on, meet others in person, and plug into the broader global CNG network.
+On September 24, 2026, CNG is coming to NYC. CNG NYC is a community meetup at [Cooper Union](https://cooper.edu/) designed to bring the local and regional CNG community together for an afternoon of demos, conversation, and a social reception. Whether you're a practitioner, researcher, or builder, this is a chance to show off what you're working on, meet others in person, and plug into the broader global CNG network. This event is being held during New York City Climate Week. 
 
 ## Submit a Talk
 
@@ -21,8 +21,8 @@ CNG NYC is part of the 2026 CNG global event series:
 
 * London | June 23
 * Tokyo | August 24
-* **NYC | September 24 at Cooper Union**
-* CNG Forum 2026 | Snowbird, UT, USA | October 6–9
+* **NYC | September 24**
+* CNG Forum 2026 | October 6–9
 * Zürich | October 29
 
 Each event agenda and audience will look different, fostering both local and international connections.

--- a/content/blog/2026/260706-call-for-speakers-cng-nyc-2026.md
+++ b/content/blog/2026/260706-call-for-speakers-cng-nyc-2026.md
@@ -1,0 +1,32 @@
+---
+date: "2026-07-06T00:00:00-06:00"
+title: "Call for Speakers: CNG NYC 2026"
+tags: []
+summary: "Submit a talk for CNG NYC 2026, a community meetup at Cooper Union on September 24."
+---
+
+On September 24, 2026, the Cloud-Native Geospatial Forum (CNG) is coming to New York City. CNG NYC is a community meetup at [Cooper Union](https://cooper.edu/) designed to bring the local and regional CNG community together for an afternoon of demos, conversation, and a social reception. Whether you're a practitioner, researcher, or builder, this is a chance to show off what you're working on, meet others in person, and plug into the broader global CNG network.
+
+## Submit a Talk
+
+We want to hear what you're building. Whether it's a production deployment, a work in progress, a tool, a workflow, or a hard-won lesson — if it touches cloud-native geospatial, there's a place for it in the program. Format will be casual, demo-style share-outs of what people are working on.
+
+[Submit your talk here](https://docs.google.com/forms/d/e/1FAIpQLSeQVIiowSsc_snVMRbkqMoN6he32uFTiT8w1oet3otwPrXUfA/viewform?usp=publish-editor).
+
+**Submission deadline: August 9, 2026**
+
+## Part of the 2026 CNG Series
+
+CNG NYC is part of the 2026 CNG global event series:
+
+* London | June 23
+* Tokyo | August 24
+* **NYC | September 24 at Cooper Union**
+* CNG Forum 2026 | Snowbird, UT, USA | October 6–9
+* Zürich | October 29
+
+Each event agenda and audience will look different, fostering both local and international connections.
+
+## Want to Get Involved?
+
+If your organization is interested in sponsoring or hosting future CNG events, we'd love to hear from you. Reach out to [hello@cloudnativegeo.org](mailto:hello@cloudnativegeo.org).

--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -3,7 +3,7 @@ date: 2026-06-23
 event_date: 2026-09-24
 title: "CNG NYC"
 display_date: "24 September 2026"
-when_time: "NYC Climate Week"
+when_time: "9 AM – 5 PM, with evening reception"
 where: "Cooper Union, New York City"
 where_short: "Cooper Union"
 description: "A CNG community gathering in New York City, co-organized with the NY Climate Exchange, during NYC Climate Week."

--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -1,0 +1,20 @@
+---
+date: 2026-06-23
+event_date: 2026-09-24
+title: "CNG NYC"
+display_date: "24 September 2026"
+when_time: "NYC Climate Week"
+where: "Cooper Union, New York City"
+where_short: "Cooper Union"
+description: "A CNG community gathering in New York City, co-organized with the NY Climate Exchange, during NYC Climate Week."
+price:
+images:
+cta_text: "Register"
+cta_url:
+hide_cta: true
+agenda:
+---
+
+Join us in New York City for a day of talks, demos, and community at [Cooper Union](https://cooper.edu) during [NYC Climate Week](https://www.climateweeknyc.org). This event brings together cloud-native geospatial practitioners in one of the world's great climate and data cities to share what they're building and connect with the broader CNG community.
+
+CNG NYC is co-organized with the [NY Climate Exchange](https://nyclimateexchange.org) and is part of the [2026 CNG global event series](/events/).

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -11,7 +11,7 @@
         {{if isset .Params "price"}}<li class="event-price"><span class="event-meta-tip">Cost:</span> {{ .Params.price | markdownify }}</li>{{ end }}
       {{ end }}
     </ul>
-    <div class="event-cta">{{if isset .Params "cta_url"}}<a href="{{ .Params.cta_url }}">{{end}}{{ .Params.cta_text }}{{if isset .Params "cta_url"}}</a>{{end}}</div>
+    {{if ne .Params.hide_cta true}}<div class="event-cta">{{if isset .Params "cta_url"}}<a href="{{ .Params.cta_url }}">{{end}}{{ .Params.cta_text }}{{if isset .Params "cta_url"}}</a>{{end}}</div>{{end}}
   </header>
   
   {{ if .Params.images }}


### PR DESCRIPTION
Adds the call for speakers announcement for CNG NYC 2026 (September 24 at Cooper Union).