### PR TITLE
Update CNG Forum 2026 event: registration link, sitewide ticket CTA

### DIFF
--- a/content/events/261006-2026-ut.md
+++ b/content/events/261006-2026-ut.md
@@ -11,7 +11,8 @@ og_card_photo: images/250603-cng-conf-open.jpg
 og_card_treatment: duotone
 hide_cta: true
 cta_text: "Get tickets"
-cta_url: "https://2026.cloudnativegeo.org"
+cta_url: "https://2026.cloudnativegeo.org/#/tickets?lang=en"
+external_url: "https://2026.cloudnativegeo.org/"
 ---
 
 Join us in Snowbird, Utah, for the second annual CNG Forum, where innovators and practitioners in the geospatial industry gather to share knowledge and advance the field.  
@@ -66,6 +67,3 @@ CNG 2026 is made possible by our founding sponsors, who are committed to advanci
 
 
 
-## **Stay informed**
-
-[Sign up](https://events.cloudnativegeo.org/cng2026interest) to receive updates on registration (and early bird pricing), the call for proposals, and sponsorship opportunities.

--- a/layouts/events/li.html
+++ b/layouts/events/li.html
@@ -1,4 +1,4 @@
 <li>
-    <a href="{{ .RelPermalink }}" class="post-title">{{ .Title }}</a><br />
+    <a href="{{ with .Params.external_url }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}" class="post-title">{{ .Title }}</a><br />
     <span class="event-date">{{ with .Params.display_date }}{{ . | markdownify }}{{ else }}{{ .Params.event_date | time.Format "02 January 2006" }}{{ end }}</span><br />
 </li>

--- a/layouts/partials/main-cta.html
+++ b/layouts/partials/main-cta.html
@@ -11,9 +11,8 @@
   <span class="cta-head">Upcoming CNG Events</span>
   {{ range first 2 $upcoming }}
   <div class="cta-event">
-    <h3><a href="{{ with .Params.external_url }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">{{ .Title }}</a></h3>
+    <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
     <p class="cta-when">{{ with .Params.display_date }}{{ . | markdownify }}{{ else }}{{ $eventDate := .Params.event_date | default .Date }}{{ time $eventDate | time.Format "02 January 2006" }}{{ end }}{{ with (.Params.where_short | default .Params.where) }} <br> {{ . }}{{ end }}</p>
-    {{ if .Params.cta_url }}<div class="main-cta-url"><a href="{{ .Params.cta_url }}">{{ if .Params.cta_text }}{{ .Params.cta_text }}{{ else }}Get tickets{{ end }}</a></div>{{ end }}
   </div>
   {{ end }}
 {{ else }}

--- a/layouts/partials/main-cta.html
+++ b/layouts/partials/main-cta.html
@@ -13,7 +13,7 @@
   <div class="cta-event">
     <h3><a href="{{ with .Params.external_url }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">{{ .Title }}</a></h3>
     <p class="cta-when">{{ with .Params.display_date }}{{ . | markdownify }}{{ else }}{{ $eventDate := .Params.event_date | default .Date }}{{ time $eventDate | time.Format "02 January 2006" }}{{ end }}{{ with (.Params.where_short | default .Params.where) }} <br> {{ . }}{{ end }}</p>
-    {{ with .Params.cta_url }}<div class="main-cta-url"><a href="{{ . }}">{{ with .Params.cta_text }}{{ . }}{{ else }}Get tickets{{ end }}</a></div>{{ end }}
+    {{ if .Params.cta_url }}<div class="main-cta-url"><a href="{{ .Params.cta_url }}">{{ if .Params.cta_text }}{{ .Params.cta_text }}{{ else }}Get tickets{{ end }}</a></div>{{ end }}
   </div>
   {{ end }}
 {{ else }}

--- a/layouts/partials/main-cta.html
+++ b/layouts/partials/main-cta.html
@@ -11,8 +11,9 @@
   <span class="cta-head">Upcoming CNG Events</span>
   {{ range first 2 $upcoming }}
   <div class="cta-event">
-    <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+    <h3><a href="{{ with .Params.external_url }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">{{ .Title }}</a></h3>
     <p class="cta-when">{{ with .Params.display_date }}{{ . | markdownify }}{{ else }}{{ $eventDate := .Params.event_date | default .Date }}{{ time $eventDate | time.Format "02 January 2006" }}{{ end }}{{ with (.Params.where_short | default .Params.where) }} <br> {{ . }}{{ end }}</p>
+    {{ with .Params.cta_url }}<div class="main-cta-url"><a href="{{ . }}">{{ with .Params.cta_text }}{{ . }}{{ else }}Get tickets{{ end }}</a></div>{{ end }}
   </div>
   {{ end }}
 {{ else }}


### PR DESCRIPTION
- Update ticket URL to registration page
- Remove outdated Stay informed sign-up section
- Events listing and sitewide sidebar link directly to 2026.cloudnativegeo.org
- Sitewide sidebar shows a Get tickets button for upcoming events