### PR TITLE
Update CNG NYC CTA URL

### DIFF
--- a/content/events/260924-nyc.md
+++ b/content/events/260924-nyc.md
@@ -10,7 +10,7 @@ description: "A CNG community gathering in New York City, co-organized with the 
 price:
 images:
 cta_text: "Submit a talk"
-cta_url: "https://docs.google.com/forms/d/e/1FAIpQLSeQVIiowSsc_snVMRbkqMoN6he32uFTiT8w1oet3otwPrXUfA/viewform?usp=sharing&ouid=118199663156641128589"
+cta_url: "https://docs.google.com/forms/d/e/1FAIpQLSeQVIiowSsc_snVMRbkqMoN6he32uFTiT8w1oet3otwPrXUfA/viewform?usp=dialog"
 hide_cta: false
 agenda:
 ---


### PR DESCRIPTION
Updates the call-to-action button URL for the CNG NYC event page to the new form link.